### PR TITLE
chore: react-jx-quickstart to 0.0.3

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -12,4 +12,4 @@ dependencies:
   version: 0.0.12
 - name: react-jx-quickstart
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.2
+  version: 0.0.3


### PR DESCRIPTION
chore: Promote react-jx-quickstart to version 0.0.3